### PR TITLE
docs: add Swift host and guest links

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,6 +12,7 @@ sidebar_position: 1
 - [Rust](https://github.com/wapc/wapc-rs)
 - [Go](https://github.com/wapc/wapc-go)
 - [JavaScript](https://github.com/wapc/wapc-js)
+- [Swift](https://github.com/wapc/wapc-swift)
 
 ## waPC Guest Implementations
 
@@ -19,6 +20,7 @@ sidebar_position: 1
 - [TinyGo](https://github.com/wapc/wapc-guest-tinygo)
 - [AssemblyScript](https://github.com/wapc/as-guest)
 - [Zig](https://github.com/wapc/wapc-guest-zig)
+- [Swift](https://github.com/wapc/wapc-guest-swift)
 
 ## Apex
 


### PR DESCRIPTION
## Summary

The Swift [host](https://github.com/wapc/wapc-swift) and [guest](https://github.com/wapc/wapc-guest-swift) implementations were missing from the website's listing

## Details

- Add the links to their respective sections

### Miscellaneous Changes

- auto-formatter added a newline at the end of file