### PR TITLE
docs: fix spec link typo in sidebar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'waPC.io',
-  tagline: 'Dinosaurs are cool',
+  tagline: 'WebAssembly Procedure Calls',
   url: 'https://wapc.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -71,15 +71,15 @@ const config = {
           },
           {
             type: 'doc',
-            docId: 'spec', 
-            label: 'waPC Protocal Details', 
+            docId: 'spec',
+            label: 'Specification',
             position: 'right'
           },
           {
-            to: 'blog', 
-            label: 'Blog', 
+            to: 'blog',
+            label: 'Blog',
             position: 'left'
-          }, 
+          },
         ],
       },
       footer: {


### PR DESCRIPTION
## Summary

Changed the typo'd and inconsistent title "waPC Protocal Details" to "Specification" in the sidebar

## Details

- "Protocal" should be "Protocol", but I just changed it to "Specification" to match the [other](https://github.com/wapc/wapc.io/blob/9ec727f45ae493215cc969d35ee5552a9247a685/src/pages/index.tsx#L62) [existing](https://github.com/wapc/wapc.io/blob/9ec727f45ae493215cc969d35ee5552a9247a685/docs/spec.md?plain=1#L2) wordings on the site
  - could also shorten to "Spec" to match the shortened "Docs & Links"

### Miscellaneous Changes

- also update tagline from what looks like the Docusaurus default (if I'm not mistaken)
  - although I didn't see this anywhere on the website or its HTML, so I'm not sure if this is even visible
  
- auto-formatter removed trailing whitespace from a few lines